### PR TITLE
Fix for https://github.com/SNAS/website/issues/40

### DIFF
--- a/site/layouts/partials/head.html
+++ b/site/layouts/partials/head.html
@@ -12,6 +12,7 @@
 
 		<link href="https://fonts.googleapis.com/css?family=Nunito+Sans:400,700" rel="stylesheet">
 
+		<!--z-index of the github-ribbon is overridden from 9999 to inherit -->
 		<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.0/gh-fork-ribbon.min.css" />
 		<!--[if lt IE 9]>
 			<link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/github-fork-ribbon-css/0.2.0/gh-fork-ribbon.ie.min.css" />

--- a/site/layouts/partials/jumbotron.html
+++ b/site/layouts/partials/jumbotron.html
@@ -1,5 +1,5 @@
 <div class="pv5 pv6-l ph3 bg-center cover" style="background-image: url('{{.image_url}}'); position: relative;">
-  <a class="github-fork-ribbon" href="https://github.com/OpenBMP" title="Fork me on GitHub">Fork me on GitHub</a>
+  <a class="github-fork-ribbon" href="https://github.com/OpenBMP" style="z-index: inherit" title="Fork me on GitHub">Fork me on GitHub</a>
 
   <div class="mw7 center ph3">
     <div class="db mb3">

--- a/site/layouts/partials/nav.html
+++ b/site/layouts/partials/nav.html
@@ -1,4 +1,4 @@
-<nav class="overflow-x-scroll overflow-x-visible-ns flex justify-between items-center center bg-white divider-grey relative">
+<nav class="overflow-y-scroll overflow-x-visible-ns flex justify-between items-center center bg-white divider-grey relative">
 
 	<!-- Logo -->
 	<a href="/" class="pa3 db mr4 h-100 w4 flex-none">


### PR DESCRIPTION
There are two changes here -
1. Change the hamburger nav menu to scroll in y direction, not x.
2. Change the z-index of github ribbon from 9999 to inherit, so that it goes behind the hamburger nav menu on small potrait resolutions like iphone.