### PR TITLE
Update links to installation and configuration files

### DIFF
--- a/site/content/docs/quick_start.md
+++ b/site/content/docs/quick_start.md
@@ -10,11 +10,8 @@ Quick Start
 
 The fastest way to start using SNAS is to install two Docker containers and configure a router to send BMP data.
 
-1. [Install AIO Container](install_aio)
+1. [Install AIO Container](../install_aio)
 
-2. [Install SNAS UI](install_ui)
+2. [Install SNAS UI](../install_ui)
 
-3. [Configure Your Router](router_config)
-
-You can add public BGP data by running [MRT2BMP Application](mrt2bmp).
-
+3. [Configure Your Router](../router_config)

--- a/site/content/docs/quick_start.md
+++ b/site/content/docs/quick_start.md
@@ -10,8 +10,8 @@ Quick Start
 
 The fastest way to start using SNAS is to install two Docker containers and configure a router to send BMP data.
 
-1. [Install AIO Container](../install_aio)
+1. [Install AIO Container](/docs/install_aio)
 
-2. [Install SNAS UI](../install_ui)
+2. [Install SNAS UI](/docs/install_ui)
 
-3. [Configure Your Router](../router_config)
+3. [Configure Your Router](/docs/router_config)


### PR DESCRIPTION
It appears that the links point the hyperlinks as being under this page rather than under the docs directory.
This should be fixed by forcing it to go up a directory.

I removed the mrt2bmp line as the link is broken and I cannot find the file in the docs directory